### PR TITLE
Added NavLink routing to layout.

### DIFF
--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, NavLink } from 'react-router-dom';
 
 import './Layout.css';
 import { auth } from '../api/config.js';
@@ -33,15 +33,15 @@ export function Layout() {
 				</main>
 				<nav className="Nav">
 					<div className="Nav-container">
-						<a href="#" className="Nav-link">
+						<NavLink to="/" className="Nav-link">
 							Home
-						</a>
-						<a href="#" className="Nav-link">
+						</NavLink>
+						<NavLink to="/list" className="Nav-link">
 							List
-						</a>
-						<a href="#" className="Nav-link">
+						</NavLink>
+						<NavLink to="/manage-list" className="Nav-link">
 							Manage List
-						</a>
+						</NavLink>
 					</div>
 				</nav>
 			</div>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -4,14 +4,6 @@ import './Layout.css';
 import { auth } from '../api/config.js';
 import { useAuth, SignInButton, SignOutButton } from '../api/useAuth.jsx';
 
-/**
- * TODO: The links defined in this file don't work!
- *
- * Instead of anchor element, they should use a component
- * from `react-router-dom` to navigate to the routes
- * defined in `App.jsx`.
- */
-
 export function Layout() {
 	const { user } = useAuth();
 	return (


### PR DESCRIPTION

## Description

Updated the navigation links to use the `<NavLink>` element from React Router to fix link functionality.

## Related Issue

closes #3

## Acceptance Criteria

- [x] The `nav` element is added to the `Layout` component
- [x] Links to the "Home", "List", and "Add item" pages of the app are In the `nav` element
- [x] The links all function as expected using  the `NavLink` component from `react-router-dom`


## Type of Changes
`Code Refactoring`

## Updates

### Before

Not a UI feature, before and after screenshots are not included.

### After

Not a UI feature, before and after screenshots are not included.

## Testing Steps / QA Criteria
Clicking **Home** leads to homepage
Clicking **List** leads to list page
Clicking **Manage List** leads to manage-list page
