### PR TITLE
Fix Missing sharedList Field for FireStore

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -105,6 +105,7 @@ export async function addUserToDatabase(user) {
 			email: user.email,
 			name: user.displayName,
 			uid: user.uid,
+			sharedLists: [],
 		});
 	}
 }


### PR DESCRIPTION
## Description

We expect to have a `sharedLists` in the user collection when a user is created

## Acceptance Criteria
- [x] `sharedLists` attribute must exist in the user collection when a new user is signed up.

## Type of Changes

bug fix

## Testing Steps / QA Criteria
- try to sign up with a new email
- go to firestore
- check the new user data
- make sure we have `sharedLists` attribute in that user.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
