### PR TITLE
Shopping List rendering for user

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,8 +29,6 @@ export function App() {
 	const { user } = useAuth();
 	const userId = user?.uid;
 	const userEmail = user?.email;
-	// console.log('userID', userId);
-	// console.log('email', userEmail)
 	/**
 	 * This custom hook takes a user ID and email and fetches
 	 * the shopping lists that the user has access to.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,6 @@ export function App() {
 	 * Check ./api/firestore.js for its implementation.
 	 */
 	const lists = useShoppingLists(userId, userEmail);
-	// console.log('lists', lists);
 	/**
 	 * This custom hook takes our token and fetches the data for our list.
 	 * Check ./api/firestore.js for its implementation.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,6 @@ export function App() {
 	 * Check ./api/firestore.js for its implementation.
 	 */
 	const data = useShoppingListData(listPath);
-
 	return (
 		<Router>
 			<Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,13 +29,15 @@ export function App() {
 	const { user } = useAuth();
 	const userId = user?.uid;
 	const userEmail = user?.email;
-
+	// console.log('userID', userId);
+	// console.log('email', userEmail)
 	/**
 	 * This custom hook takes a user ID and email and fetches
 	 * the shopping lists that the user has access to.
 	 * Check ./api/firestore.js for its implementation.
 	 */
 	const lists = useShoppingLists(userId, userEmail);
+	// console.log('lists', lists);
 	/**
 	 * This custom hook takes our token and fetches the data for our list.
 	 * Check ./api/firestore.js for its implementation.

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -30,9 +30,6 @@ export function useShoppingLists(userId, userEmail) {
 
 		// When we get a userEmail, we use it to subscribe to real-time updates
 		const userDocRef = doc(db, 'users', userEmail);
-		// console.log('database', db)
-		// console.log('email', userEmail)
-		// console.log('id', userId)
 		onSnapshot(userDocRef, (docSnap) => {
 			if (docSnap.exists()) {
 				const listRefs = docSnap.data().sharedLists;

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -30,12 +30,18 @@ export function useShoppingLists(userId, userEmail) {
 
 		// When we get a userEmail, we use it to subscribe to real-time updates
 		const userDocRef = doc(db, 'users', userEmail);
-
+		// console.log('database', db)
+		// console.log('email', userEmail)
+		// console.log('id', userId)
 		onSnapshot(userDocRef, (docSnap) => {
 			if (docSnap.exists()) {
 				const listRefs = docSnap.data().sharedLists;
+				console.log('listRefs', listRefs);
 				const newData = listRefs.map((listRef) => {
 					// We keep the list's id and path so we can use them later.
+					console.log('listRef, ln 41', listRef);
+					console.log('list id', listRef.id);
+					console.log('list path', listRef.path);
 					return { name: listRef.id, path: listRef.path };
 				});
 				setData(newData);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -36,12 +36,8 @@ export function useShoppingLists(userId, userEmail) {
 		onSnapshot(userDocRef, (docSnap) => {
 			if (docSnap.exists()) {
 				const listRefs = docSnap.data().sharedLists;
-				console.log('listRefs', listRefs);
 				const newData = listRefs.map((listRef) => {
 					// We keep the list's id and path so we can use them later.
-					console.log('listRef, ln 41', listRef);
-					console.log('list id', listRef.id);
-					console.log('list path', listRef.path);
 					return { name: listRef.id, path: listRef.path };
 				});
 				setData(newData);

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,7 +1,6 @@
 import './SingleList.css';
 
 export function SingleList({ name, path, setListPath }) {
-	console.log(name);
 	function handleClick() {
 		setListPath(path);
 	}

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,6 +1,7 @@
 import './SingleList.css';
 
 export function SingleList({ name, path, setListPath }) {
+	console.log(name);
 	function handleClick() {
 		setListPath(path);
 	}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,16 +1,23 @@
 import './Home.css';
+import { SingleList } from '../components/SingleList.jsx';
 
 export function Home({ data, setListPath }) {
+	console.log(data);
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `lists` array
-				 * so we can see which lists the user has access to.
-				 */}
+				{data.map((item) => {
+					return (
+						<SingleList
+							name={item.name}
+							path={item.path}
+							setListPath={setListPath}
+						/>
+					);
+				})}
 			</ul>
 		</div>
 	);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -2,16 +2,16 @@ import './Home.css';
 import { SingleList } from '../components/SingleList.jsx';
 
 export function Home({ data, setListPath }) {
-	console.log(data);
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
 			<ul>
-				{data.map((item) => {
+				{data.map((item, index) => {
 					return (
 						<SingleList
+							key={index}
 							name={item.name}
 							path={item.path}
 							setListPath={setListPath}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,11 +7,9 @@ export function List({ data }) {
 				Hello from the <code>/list</code> page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `data` array
-				 * using the `ListItem` component that's imported at the top
-				 * of this file.
-				 */}
+				{data.map((item, index) => {
+					return <ListItem key={index} name={item.id} />;
+				})}
 			</ul>
 		</>
 	);


### PR DESCRIPTION

## Description

This enables a user to view the shared lists for their email as well as the list items of those shared lists. 

## Related Issue

closes #2 

## Acceptance Criteria

- [x] The `useShoppingLists` hook is used in `App.jsx` to get the shopping lists a user has access to from the database
- [x] The lists are passed into the `Home` component as a prop named `data`
- [x] The `setListPath` function is passed into the `Home` component so we can update the current list
- [x] The `useShoppingListData` hook is used in `App.jsx` to get the items in the current list from the Firestore database
- [x] The list is passed into the `List` component as a prop named `data`
- [x] In `Home.jsx`, the `SingleList` component is used to render the name of each shopping list a user is subscribed to
- [x] In `List.jsx`, the `ListItem` component is used to render the name of each item

## Type of Changes

`new feature`

## Updates


### Before
![Screenshot 2024-02-07 at 12 29 02 PM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/c4983eef-7602-4679-b0de-b90e8c850cfe)
![Screenshot 2024-02-07 at 12 29 53 PM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/dcdd3aec-5538-4622-be57-4447081eae93)

### After
![Screenshot 2024-02-07 at 12 30 13 PM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/1c7b89a6-2586-47fb-8304-349dee3fb503)
![Screenshot 2024-02-07 at 12 30 49 PM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/668cd11e-6a45-4ff3-afec-e25bfa4b2d9b)

## Testing Steps / QA Criteria

1. Review preview deployment that is based off this PR:
2. When on home page - sign in, review if 'dinner' list appears (shared list)
3. Click dinner to ensure local storage retrieves database info
4. navigate to [deployment address]/list
5. confirm that 'milk' and 'eggs' are visible within dinner list route
