### PR TITLE
Add list filtering functionality

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,9 +1,8 @@
 import { ListItem } from '../components';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export function List({ data }) {
 	const [searchTerm, setSearchTerm] = useState('');
-	const [filteredData, setFilteredData] = useState(data);
 
 	const handleChange = (e) => {
 		setSearchTerm(e.target.value);
@@ -11,18 +10,13 @@ export function List({ data }) {
 
 	const reset = (e) => {
 		e.preventDefault();
-		setFilteredData(data);
 		setSearchTerm('');
 	};
 
-	useEffect(() => {
-		setFilteredData(
-			data.filter((item) => {
-				const itemName = item.name.toLowerCase();
-				return itemName.includes(searchTerm.toLowerCase());
-			}),
-		);
-	}, [data, searchTerm]);
+	const filteredData = data.filter((item) => {
+		const itemName = item.name.toLowerCase();
+		return itemName.includes(searchTerm.toLowerCase());
+	});
 
 	return (
 		<>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,13 +1,49 @@
 import { ListItem } from '../components';
+import { useState, useEffect } from 'react';
 
 export function List({ data }) {
+	const [searchTerm, setSearchTerm] = useState('');
+	const [filteredData, setFilteredData] = useState(data);
+
+	const handleChange = (e) => {
+		setSearchTerm(e.target.value);
+	};
+
+	const reset = (e) => {
+		e.preventDefault();
+		setFilteredData(data);
+		setSearchTerm('');
+	};
+
+	useEffect(() => {
+		setFilteredData(
+			data.filter((item) => {
+				const itemName = item.name.toLowerCase();
+				return itemName.includes(searchTerm.toLowerCase());
+			}),
+		);
+	}, [data, searchTerm]);
+
 	return (
 		<>
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
+			<form>
+				<label htmlFor="itemFilter">
+					Search for an item:
+					<input
+						type="text"
+						id="itemFilter"
+						name="itemFilter"
+						value={searchTerm}
+						onChange={handleChange}
+					/>
+				</label>
+				{searchTerm && <button onClick={reset}>Reset</button>}
+			</form>
 			<ul>
-				{data.map((item, index) => {
+				{filteredData.map((item) => {
 					return <ListItem key={item.id} name={item.name} />;
 				})}
 			</ul>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

Added a form to ```List``` component that allows the user to filter items in the list by the item's name. 

## Related Issue

closes #7 

## Acceptance Criteria

- [x] A form is added to the top of the `List` view, above the shopping list
- [x] The form includes the following elements
	- A text field (with semantic `<label>`!) which narrows down the list as the user types
	- When there’s text in the field, some kind of button (e.g., an X) to clear the field. When the field is cleared, the list is reset to its unfiltered state.


## Type of Changes

New  Feature

## Updates

### Before

<img width="711" alt="image" src="https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/137969744/a12daf14-fe38-44f5-9324-205c1dd2d5b9">


### After

<img width="833" alt="image" src="https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/137969744/5bb60e20-75ea-46cc-9a6a-960ca8dbcb6f">

<img width="753" alt="image" src="https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/137969744/328c805a-078a-47b5-ad71-34aab3c5f6a0">


## Testing Steps / QA Criteria

- Sign in and select dinner list
- Navigate to the list page
- Enter in search term 
- ```Reset``` button should only be visible when there is text in the field
- Verify that letter casing does not affect search results
- Verify that the search results return anything that matches the search term, even if it is the middle or end of an item name
- Verify that deleting previously typed characters updates the list
- Verify that entering new characters updates the list
- Hitting reset should reset the list to show all items **and** clear the search field
- Verify that form is accessible by navigating with keyboard
