### PR TITLE
Et sm empty list welcome

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,7 +55,10 @@ export function App() {
 							/>
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listPath={listPath} />}
+					/>
 					<Route
 						path="/manage-list"
 						element={<ManageList listPath={listPath} userId={userId} />}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -18,24 +18,25 @@ export function List({ data }) {
 		return itemName.includes(searchTerm.toLowerCase());
 	});
 
+	console.log(data);
+
 	return (
 		<>
-			<p>
-				Hello from the <code>/list</code> page!
-			</p>
-			<form>
-				<label htmlFor="itemFilter">
-					Search for an item:
-					<input
-						type="text"
-						id="itemFilter"
-						name="itemFilter"
-						value={searchTerm}
-						onChange={handleChange}
-					/>
-				</label>
-				{searchTerm && <button onClick={reset}>Reset</button>}
-			</form>
+			{data.length > 0 && (
+				<form>
+					<label htmlFor="itemFilter">
+						Search for an item:
+						<input
+							type="text"
+							id="itemFilter"
+							name="itemFilter"
+							value={searchTerm}
+							onChange={handleChange}
+						/>
+					</label>
+					{searchTerm && <button onClick={reset}>Reset</button>}
+				</form>
+			)}
 			<ul>
 				{filteredData.map((item) => {
 					return <ListItem key={item.id} name={item.name} />;

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -27,15 +27,15 @@ export function List({ data, listPath }) {
 
 	return (
 		<>
-			{!listPath && (
+			{!listPath ? (
 				<>
 					<h2>
 						You haven't selected a list yet. Click below to select a list.
 					</h2>
 					<button onClick={() => handleClick('/')}>Select a list</button>
 				</>
-			)}
-			{listPath && data.length === 0 && (
+			) : null}
+			{listPath && data.length === 0 ? (
 				<>
 					<h2>
 						This list is currently empty. Click below to add your first item.
@@ -44,8 +44,8 @@ export function List({ data, listPath }) {
 						Add first item
 					</button>
 				</>
-			)}
-			{data.length > 0 && (
+			) : null}
+			{data.length > 0 ? (
 				<form>
 					<label htmlFor="itemFilter">
 						Search for an item:
@@ -57,9 +57,9 @@ export function List({ data, listPath }) {
 							onChange={handleChange}
 						/>
 					</label>
-					{searchTerm && <button onClick={reset}>Reset</button>}
+					{searchTerm ? <button onClick={reset}>Reset</button> : null}
 				</form>
-			)}
+			) : null}
 			<ul>
 				{filteredData.map((item) => {
 					return <ListItem key={item.id} name={item.name} />;

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,8 +1,11 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-export function List({ data }) {
+export function List({ data, listPath }) {
 	const [searchTerm, setSearchTerm] = useState('');
+
+	const navigate = useNavigate();
 
 	const handleChange = (e) => {
 		setSearchTerm(e.target.value);
@@ -13,21 +16,33 @@ export function List({ data }) {
 		setSearchTerm('');
 	};
 
+	const handleClick = (selectedPath) => {
+		navigate(selectedPath);
+	};
+
 	const filteredData = data.filter((item) => {
 		const itemName = item.name.toLowerCase();
 		return itemName.includes(searchTerm.toLowerCase());
 	});
 
-	console.log(data);
-
 	return (
 		<>
-			{data.length === 0 && (
+			{!listPath && (
+				<>
+					<h2>
+						You haven't selected a list yet. Click below to select a list.
+					</h2>
+					<button onClick={() => handleClick('/')}>Select a list</button>
+				</>
+			)}
+			{listPath && data.length === 0 && (
 				<>
 					<h2>
 						This list is currently empty. Click below to add your first item.
 					</h2>
-					<button>Add first item</button>
+					<button onClick={() => handleClick('/manage-list')}>
+						Add first item
+					</button>
 				</>
 			)}
 			{data.length > 0 && (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -22,6 +22,14 @@ export function List({ data }) {
 
 	return (
 		<>
+			{data.length === 0 && (
+				<>
+					<h2>
+						This list is currently empty. Click below to add your first item.
+					</h2>
+					<button>Add first item</button>
+				</>
+			)}
 			{data.length > 0 && (
 				<form>
 					<label htmlFor="itemFilter">


### PR DESCRIPTION
## Description

This PR sets up a welcome message to the user that reflects whether or not the list they are viewing is empty or not, as well as checks whether or not a user has yet selected a list before navigating to the List view.

## Related Issue

Closes #8 

## Acceptance Criteria

- [x] The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

`Feature`

## Updates

### Before

![Screenshot 2024-02-27 at 8 11 16 AM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/30fc2e8d-1327-4e55-8920-12d9ff96f612)


### After

Logged in user - after navigating to list that is empty:

![Screenshot 2024-02-27 at 8 15 25 AM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/da1bd72b-e283-4351-a1bb-ce9dd51a4805)

Added prompt to select list (and button to go home) when user skips to List view without clicking list on Home:

![Screenshot 2024-02-27 at 8 12 30 AM](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/117242156/42362974-79d0-4228-9fcd-a566f2ba8730)


## Testing Steps / QA Criteria

Testing for AC / empty list prompt:

1. Navigate to test deployment below, sign in
2. To avoid bugs, clear local storage after navigating to test deployment.
3. Make a new list by using form on Home view - this should redirect user to List view 
4. Confirm message indicates that new list is empty, click button to continue
5. Confirm that button redirects user to ManageList view

Testing for edge case - user has not selected a list before navigating to List view:
1. Navigate to test deployment below, sign in
2. Clear local storage
3. Navigate using buttons on bottom of screen to List view (without clicking anything but sign in beforehand)
4. Confirm message indicates that user has not selected list
5. Click button to confirm it redirects to Home view to enable list selection