### PR TITLE
Issue #9 - Marking item as purchased

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,7 +55,10 @@ export function App() {
 							/>
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listPath={listPath} />}
+					/>
 					<Route
 						path="/manage-list"
 						element={<ManageList listPath={listPath} userId={userId} />}

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,6 +7,7 @@ import {
 	doc,
 	onSnapshot,
 	updateDoc,
+	increment,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -186,8 +187,17 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	return newItem;
 }
 
-export async function updateItem(dateLastPurchased, totalPurchases) {
-	console.log(dateLastPurchased, totalPurchases);
+// export async function updateItem(listPath, itemID) {
+export async function updateItem(listPath, itemID) {
+	// console.log(listPath, itemID);
+	// console.log(listPath, itemID)
+	const listRef = doc(db, listPath, 'items', itemID);
+
+	updateDoc(listRef, {
+		dateLastPurchased: new Date(),
+		totalPurchases: increment(1),
+	}).then(console.log('backend'));
+
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item. You'll need to figure out what arguments

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -187,7 +187,6 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	return newItem;
 }
 
-// export async function updateItem(listPath, itemID) {
 export async function updateItem(listPath, itemID, isChecked) {
 	const listRef = doc(db, listPath, 'items', itemID);
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,7 +190,6 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 // export async function updateItem(listPath, itemID) {
 export async function updateItem(listPath, itemID, isChecked) {
 	const listRef = doc(db, listPath, 'items', itemID);
-	console.log(isChecked);
 
 	await updateDoc(listRef, {
 		dateLastPurchased: isChecked ? new Date() : null,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -189,21 +189,12 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 
 // export async function updateItem(listPath, itemID) {
 export async function updateItem(listPath, itemID) {
-	// console.log(listPath, itemID);
-	// console.log(listPath, itemID)
 	const listRef = doc(db, listPath, 'items', itemID);
 
 	await updateDoc(listRef, {
 		dateLastPurchased: new Date(),
 		totalPurchases: increment(1),
 	});
-	console.log('updated');
-
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
 }
 
 export async function deleteItem() {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -192,15 +192,12 @@ export async function updateItem(listPath, itemID) {
 	// console.log(listPath, itemID);
 	// console.log(listPath, itemID)
 	const listRef = doc(db, listPath, 'items', itemID);
-	try {
-		await updateDoc(listRef, {
-			dateLastPurchased: new Date(),
-			totalPurchases: increment(1),
-		});
-		console.log('updated');
-	} catch (error) {
-		console.error(error.message);
-	}
+
+	await updateDoc(listRef, {
+		dateLastPurchased: new Date(),
+		totalPurchases: increment(1),
+	});
+	console.log('updated');
 
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -191,8 +191,6 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 export async function updateItem(listPath, itemID, isChecked) {
 	const listRef = doc(db, listPath, 'items', itemID);
 
-	console.log(isChecked);
-
 	await updateDoc(listRef, {
 		dateLastPurchased: isChecked ? new Date() : null,
 		totalPurchases: isChecked ? increment(1) : increment(-1),

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -188,12 +188,14 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 }
 
 // export async function updateItem(listPath, itemID) {
-export async function updateItem(listPath, itemID) {
+export async function updateItem(listPath, itemID, isChecked) {
 	const listRef = doc(db, listPath, 'items', itemID);
 
+	console.log(isChecked);
+
 	await updateDoc(listRef, {
-		dateLastPurchased: new Date(),
-		totalPurchases: increment(1),
+		dateLastPurchased: isChecked ? new Date() : null,
+		totalPurchases: isChecked ? increment(1) : increment(-1),
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -186,7 +186,8 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	return newItem;
 }
 
-export async function updateItem() {
+export async function updateItem(dateLastPurchased, totalPurchases) {
+	console.log(dateLastPurchased, totalPurchases);
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item. You'll need to figure out what arguments

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -190,6 +190,7 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 // export async function updateItem(listPath, itemID) {
 export async function updateItem(listPath, itemID, isChecked) {
 	const listRef = doc(db, listPath, 'items', itemID);
+	console.log(isChecked);
 
 	await updateDoc(listRef, {
 		dateLastPurchased: isChecked ? new Date() : null,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -192,11 +192,15 @@ export async function updateItem(listPath, itemID) {
 	// console.log(listPath, itemID);
 	// console.log(listPath, itemID)
 	const listRef = doc(db, listPath, 'items', itemID);
-
-	updateDoc(listRef, {
-		dateLastPurchased: new Date(),
-		totalPurchases: increment(1),
-	}).then(console.log('backend'));
+	try {
+		await updateDoc(listRef, {
+			dateLastPurchased: new Date(),
+			totalPurchases: increment(1),
+		});
+		console.log('updated');
+	} catch (error) {
+		console.error(error.message);
+	}
 
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -33,13 +33,27 @@ export function ListItem({ listPath, item }) {
 		purchaseItem();
 	};
 
+	//Calculate time remaining if purchase was less than 24 hours ago
+	const updateTimer = () => {
+		if (item.dateLastPurchased) {
+			const timeElapsed = Date.now() - item.dateLastPurchased.seconds * 1000;
+			if (timeElapsed < ONE_DAY_IN_MILLISECONDS) {
+				return ONE_DAY_IN_MILLISECONDS - timeElapsed;
+			} else {
+				return 0;
+			}
+		}
+	};
+
 	//sets a timer to uncheck an item 24 hours after it's purchased
 	useEffect(() => {
+		let timeRemaining = updateTimer();
+
 		const timer = setTimeout(() => {
-			if (purchasedOneDayAgo) {
+			if (timeRemaining > 0) {
 				setIsChecked(false);
 			}
-		}, ONE_DAY_IN_MILLISECONDS);
+		}, timeRemaining);
 		return () => clearTimeout(timer);
 	}, [isChecked, purchasedOneDayAgo]);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -21,7 +21,7 @@ export function ListItem({ listPath, item }) {
 	}, [item.dateLastPurchased]);
 
 	const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
-	function changeHandler(e) {
+	const changeHandler = (e) => {
 		setIsChecked(!isChecked);
 		async function purchaseItem() {
 			try {
@@ -31,7 +31,7 @@ export function ListItem({ listPath, item }) {
 			}
 		}
 		purchaseItem();
-	}
+	};
 
 	//sets a timer to uncheck an item 24 hours after it's purchased
 	useEffect(() => {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,25 +1,28 @@
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
+import { useState, useEffect } from 'react';
 
-export function ListItem({ item }) {
-	let isPurchased = false;
+export function ListItem({ listPath, item }) {
+	const [isPurchased, setIsPurchased] = useState(false);
 
 	function changeHandler(e) {
-		isPurchased = !isPurchased;
-		purchaseItem();
+		console.log('Is purchased before flipping ' + isPurchased);
+		setIsPurchased(!isPurchased);
 	}
 
-	async function purchaseItem() {
-		console.log(isPurchased);
-		let today = new Date();
-		if (isPurchased) {
-			try {
-				await updateItem(today, item.totalPurchases);
-			} catch (error) {
-				console.log(error);
+	useEffect(() => {
+		async function purchaseItem() {
+			if (isPurchased) {
+				console.log(isPurchased + ' is purchased!');
+				try {
+					await updateItem(listPath, item.id);
+				} catch (error) {
+					alert(error.message);
+				}
 			}
 		}
-	}
+		purchaseItem();
+	}, [isPurchased, item.id, listPath]);
 
 	//potential future issue: feature that allows user to uncheck mistakenly checked items without updating database
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,10 +1,10 @@
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates.js';
 
 export function ListItem({ listPath, item }) {
-	const purchasedOneDayAgo = useCallback(() => {
+	const purchasedOneDayAgo = useMemo(() => {
 		if (item.dateLastPurchased !== null) {
 			const timeDiff = Date.now() - item.dateLastPurchased.seconds * 1000;
 			if (timeDiff <= ONE_DAY_IN_MILLISECONDS) {
@@ -17,37 +17,48 @@ export function ListItem({ listPath, item }) {
 		}
 	}, [item.dateLastPurchased]);
 
-	const [isPurchased, setIsPurchased] = useState(false);
 	const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
 	function changeHandler(e) {
-		setIsPurchased(!isPurchased);
+		// setIsPurchased(!isPurchased);
 		setIsChecked(!isChecked);
-	}
-
-	useEffect(() => {
 		async function purchaseItem() {
-			if (isPurchased) {
-				try {
-					await updateItem(listPath, item.id);
-				} catch (error) {
-					alert(error.message);
-				}
+			try {
+				await updateItem(listPath, item.id, !isChecked);
+			} catch (error) {
+				alert(error.message);
 			}
 		}
 		purchaseItem();
-	}, [isPurchased, item.id, listPath]);
+	}
+
+	// const [isPurchased, setIsPurchased] = useState(false);
+	// const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
+	// function changeHandler(e) {
+	// setIsPurchased(!isPurchased);
+	// 	setIsChecked(!isChecked);
+	// }
+
+	// useEffect(() => {
+	// 	async function purchaseItem() {
+	// 		if (isChecked) {
+	// 			try {
+	// 				await updateItem(listPath, item.id, isChecked);
+	// 			} catch (error) {
+	// 				alert(error.message);
+	// 			}
+	// 		}
+	// 	}
+	// 	purchaseItem();
+	// }, [isChecked, item.id, listPath]);
 
 	useEffect(() => {
 		const timer = setTimeout(() => {
 			if (purchasedOneDayAgo) {
-				console.log(item.name);
 				setIsChecked(false);
 			}
-		}, 10000);
+		}, ONE_DAY_IN_MILLISECONDS);
 		return () => clearTimeout(timer);
 	}, [isChecked, purchasedOneDayAgo]);
-
-	//potential future issue: feature that allows user to uncheck mistakenly checked items without updating database
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,48 @@
 import './ListItem.css';
+import { useState } from 'react';
+import { updateItem } from '../api/firebase.js';
 
-export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+export function ListItem({ item }) {
+	// const formData = {
+	// 	dateLastPurchased: item.dateLastPurchased,
+	// 	totalPurchases: item.totalPurchases,
+	// 	purchased: false,
+	// };
+	const [isPurchased, setIsPurchased] = useState(false);
+	// const [updatedItem, setUpdatedItem] = useState(formData);
+
+	function changeHandler(e) {
+		setIsPurchased(!isPurchased);
+	}
+
+	async function purchaseItem() {
+		let today = new Date();
+		if (isPurchased) {
+			try {
+				await updateItem(today, item.totalPurchases);
+			} catch (error) {
+				console.log(error);
+			}
+		}
+	}
+
+	//const [isPurchased, setIsPurchased] = useState(false);
+	//const toggleIsPurchased = () => setIsPurchased(!isPurchased)
+	//potential future issue: feature that allows user to uncheck mistakenly checked items without updating database
+	//await updateItem(listPath, {updatedItem.dateLastPurchased, updatedItem.totalPurchases})
+
+	return (
+		<li className="ListItem">
+			<label htmlFor={item.name}>
+				{item.name}
+				<input
+					type="checkbox"
+					id={item.name}
+					name="purchased"
+					value={isPurchased}
+					onChange={changeHandler}
+				/>
+			</label>
+		</li>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -50,7 +50,7 @@ export function ListItem({ listPath, item }) {
 		let timeRemaining = updateTimer();
 
 		const timer = setTimeout(() => {
-			if (timeRemaining > 0) {
+			if (purchasedOneDayAgo) {
 				setIsChecked(false);
 			}
 		}, timeRemaining);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,21 +1,16 @@
 import './ListItem.css';
-import { useState } from 'react';
 import { updateItem } from '../api/firebase.js';
 
 export function ListItem({ item }) {
-	// const formData = {
-	// 	dateLastPurchased: item.dateLastPurchased,
-	// 	totalPurchases: item.totalPurchases,
-	// 	purchased: false,
-	// };
-	const [isPurchased, setIsPurchased] = useState(false);
-	// const [updatedItem, setUpdatedItem] = useState(formData);
+	let isPurchased = false;
 
 	function changeHandler(e) {
-		setIsPurchased(!isPurchased);
+		isPurchased = !isPurchased;
+		purchaseItem();
 	}
 
 	async function purchaseItem() {
+		console.log(isPurchased);
 		let today = new Date();
 		if (isPurchased) {
 			try {
@@ -26,10 +21,7 @@ export function ListItem({ item }) {
 		}
 	}
 
-	//const [isPurchased, setIsPurchased] = useState(false);
-	//const toggleIsPurchased = () => setIsPurchased(!isPurchased)
 	//potential future issue: feature that allows user to uncheck mistakenly checked items without updating database
-	//await updateItem(listPath, {updatedItem.dateLastPurchased, updatedItem.totalPurchases})
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -8,16 +8,12 @@ export function ListItem({ listPath, item }) {
 	On render, box is checked if purchased less than a day ago */
 
 	const purchasedOneDayAgo = useMemo(() => {
-		if (item.dateLastPurchased !== null) {
-			const timeDiff = Date.now() - item.dateLastPurchased.seconds * 1000;
-			if (timeDiff <= ONE_DAY_IN_MILLISECONDS) {
-				return true;
-			} else {
-				return false;
-			}
-		} else {
+		if (item.dateLastPurchased === null) {
 			return false;
 		}
+
+		const timeDiff = Date.now() - item.dateLastPurchased.seconds * 1000;
+		return timeDiff <= ONE_DAY_IN_MILLISECONDS;
 	}, [item.dateLastPurchased]);
 
 	const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,6 +4,9 @@ import { useState, useEffect, useMemo } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates.js';
 
 export function ListItem({ listPath, item }) {
+	/* Returns a boolean that is passed into isChecked useState
+	On render, box is checked if purchased less than a day ago */
+
 	const purchasedOneDayAgo = useMemo(() => {
 		if (item.dateLastPurchased !== null) {
 			const timeDiff = Date.now() - item.dateLastPurchased.seconds * 1000;
@@ -19,7 +22,6 @@ export function ListItem({ listPath, item }) {
 
 	const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
 	function changeHandler(e) {
-		// setIsPurchased(!isPurchased);
 		setIsChecked(!isChecked);
 		async function purchaseItem() {
 			try {
@@ -31,26 +33,7 @@ export function ListItem({ listPath, item }) {
 		purchaseItem();
 	}
 
-	// const [isPurchased, setIsPurchased] = useState(false);
-	// const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
-	// function changeHandler(e) {
-	// setIsPurchased(!isPurchased);
-	// 	setIsChecked(!isChecked);
-	// }
-
-	// useEffect(() => {
-	// 	async function purchaseItem() {
-	// 		if (isChecked) {
-	// 			try {
-	// 				await updateItem(listPath, item.id, isChecked);
-	// 			} catch (error) {
-	// 				alert(error.message);
-	// 			}
-	// 		}
-	// 	}
-	// 	purchaseItem();
-	// }, [isChecked, item.id, listPath]);
-
+	//sets a timer to uncheck an item 24 hours after it's purchased
 	useEffect(() => {
 		const timer = setTimeout(() => {
 			if (purchasedOneDayAgo) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -43,14 +43,14 @@ export function ListItem({ listPath, item }) {
 
 	//sets a timer to uncheck an item 24 hours after it's purchased
 	useEffect(() => {
-		let timeRemaining = updateTimer();
+		if (purchasedOneDayAgo) {
+			let timeRemaining = updateTimer();
 
-		const timer = setTimeout(() => {
-			if (purchasedOneDayAgo) {
+			const timer = setTimeout(() => {
 				setIsChecked(false);
-			}
-		}, timeRemaining);
-		return () => clearTimeout(timer);
+			}, timeRemaining);
+			return () => clearTimeout(timer);
+		}
 	}, [isChecked, purchasedOneDayAgo]);
 
 	return (

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,4 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
 
-export function List({ data }) {
+export function List({ listPath, data }) {
 	const [searchTerm, setSearchTerm] = useState('');
 
 	const handleChange = (e) => {
@@ -38,7 +38,7 @@ export function List({ data }) {
 			</form>
 			<ul>
 				{filteredData.map((item) => {
-					return <ListItem key={item.id} item={item} />;
+					return <ListItem key={item.id} item={item} listPath={listPath} />;
 				})}
 			</ul>
 		</>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -38,7 +38,7 @@ export function List({ data }) {
 			</form>
 			<ul>
 				{filteredData.map((item) => {
-					return <ListItem key={item.id} name={item.name} />;
+					return <ListItem key={item.id} item={item} />;
 				})}
 			</ul>
 		</>


### PR DESCRIPTION
## Description

This PR enables a user to mark a list item as purchased and initiates a timer to uncheck a purchased item after 24 hours so they may buy it again.
- Created the `updateItem` function in the `firebase.js` API
- Checkbox type `input` next to each list item
- `setTimeout` used to uncheck a purchased item after 24 hours
- Change handler and `useState` to determine if an item has been checked and call `updateItem` function

## Related Issue

Closes #9 

## Acceptance Criteria

- [X] The `ListItem` component renders a checkbox with a semantic `<label>`.
- [X] Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document
- [X] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [X] The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked

## Type of Changes

`New feature`

## Updates

### Before

<img width="776" alt="image" src="https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/137969744/89411c72-75cb-4911-8ccf-4eb27b9ddbd5">

### After

<img width="758" alt="image" src="https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/137969744/988ceae7-50bb-430f-bede-98ebfdfbb32e">


## Testing Steps / QA Criteria

1. Sign in and select the dinner shopping list
2. Navigate to List view
3. Verify that clicking the item name or pressing tab on the keyboard highlights the checkbox for an item
4. In Firebase, open the dinner list, and open an item to view the item's ```totalPurchases``` and ```dateLastPurchased```.
5. In the app, click on an item's checkbox. Verify in Firebase that the item's ```totalPurchases``` has increased by one and that the ```dateLastPurchased``` has been updated to the current date and time.
6. Verify that unchecking the item decreases the ```totalPurchases``` by one, and updates ```dateLastPurchased``` to ```null```.
7. In Firebase, change the date for ```dateLastPurchased``` to more than a day previous. Confirm that upon List page refresh, the item is unchecked if ```dateLastPurchased``` is more than a day prior.

