### PR TITLE
Fix list item checkbox behavior

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,6 @@
 import './ListItem.css';
 import { updateItem, deleteItem } from '../api/firebase.js';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates.js';
 import { purchaseUrgency } from '../utils/hooks.js';
 
@@ -13,7 +13,7 @@ export function ListItem({ listPath, item }) {
 	//Boolean to pass into isChecked state
 	const purchasedWithinDay = () => {
 		//Exclude new, never purchased items - new items are added to db with same dateCreated + first dateLastPurchased
-		if (item.dateCreated.seconds == lastPurchase.seconds) {
+		if (item.dateCreated.seconds === lastPurchase.seconds) {
 			return false;
 		} else {
 			return timeElapsed <= ONE_DAY_IN_MILLISECONDS;
@@ -24,12 +24,15 @@ export function ListItem({ listPath, item }) {
 	const [isChecked, setIsChecked] = useState(purchasedWithinDay);
 
 	//If item is checked on render, calculate time until isChecked state is set to false/unchecked
-	if (purchasedWithinDay) {
-		const timeRemaining = ONE_DAY_IN_MILLISECONDS - timeElapsed;
-		setTimeout(() => {
-			setIsChecked(false);
-		}, timeRemaining);
-	}
+	useEffect(() => {
+		if (isChecked) {
+			const timeRemaining = ONE_DAY_IN_MILLISECONDS - timeElapsed;
+			const timer = setTimeout(() => {
+				setIsChecked(false);
+			}, timeRemaining);
+			return () => clearTimeout(timer);
+		}
+	}, [isChecked, timeElapsed]);
 
 	const changeHandler = (e) => {
 		setIsChecked(!isChecked);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -12,7 +12,7 @@ export function ListItem({ listPath, item }) {
 
 	//Boolean to pass into isChecked state
 	const purchasedWithinDay = () => {
-		//Exclude items that were just created and have never been purchased - new items are added to db with same dateCreated and first dateLastPurchased.
+		//Exclude new, never purchased items - new items are added to db with same dateCreated + first dateLastPurchased
 		if (item.dateCreated.seconds == lastPurchase.seconds) {
 			return false;
 		} else {
@@ -22,6 +22,14 @@ export function ListItem({ listPath, item }) {
 
 	//Box is checked on render if purchased within 24 hrs
 	const [isChecked, setIsChecked] = useState(purchasedWithinDay);
+
+	//If item is checked on render, calculate time until isChecked state is set to false/unchecked
+	if (purchasedWithinDay) {
+		const timeRemaining = ONE_DAY_IN_MILLISECONDS - timeElapsed;
+		setTimeout(() => {
+			setIsChecked(false);
+		}, timeRemaining);
+	}
 
 	const changeHandler = (e) => {
 		setIsChecked(!isChecked);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -35,10 +35,10 @@ export function ListItem({ listPath, item }) {
 	}, [isChecked, timeElapsed]);
 
 	const changeHandler = (e) => {
-		setIsChecked(!isChecked);
 		async function purchaseItem() {
 			try {
 				await updateItem(listPath, item.id, !isChecked);
+				setIsChecked(!isChecked);
 			} catch (error) {
 				alert(error.message);
 			}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -5,19 +5,16 @@ import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates.js';
 import { purchaseUrgency } from '../utils/hooks.js';
 
 export function ListItem({ listPath, item }) {
-	/* Returns a boolean that is passed into isChecked useState
-	On render, box is checked if purchased less than a day ago */
+	//Time variables for each item on render
+	const lastPurchase =
+		item.dateLastPurchased[item.dateLastPurchased.length - 1];
+	const timeElapsed = Date.now() - lastPurchase.seconds * 1000;
+	//Boolean to pass into isChecked state
+	const purchasedWithinDay = timeElapsed <= ONE_DAY_IN_MILLISECONDS;
 
-	const purchasedOneDayAgo = useMemo(() => {
-		if (item.dateLastPurchased === null) {
-			return false;
-		}
+	//Box is checked on render if purchased within 24 hrs
+	const [isChecked, setIsChecked] = useState(purchasedWithinDay);
 
-		const timeDiff = Date.now() - item.dateLastPurchased.seconds * 1000;
-		return timeDiff <= ONE_DAY_IN_MILLISECONDS;
-	}, [item.dateLastPurchased]);
-
-	const [isChecked, setIsChecked] = useState(purchasedOneDayAgo);
 	const changeHandler = (e) => {
 		setIsChecked(!isChecked);
 		async function purchaseItem() {
@@ -31,35 +28,34 @@ export function ListItem({ listPath, item }) {
 	};
 
 	const deleteHandler = async (e) => {
-		// Note: Should we add more user feedback when items are successfully deleted? Some might further interrupt usability.
 		if (window.confirm(`Are you sure you'd like to delete ${item.name}?`)) {
 			await deleteItem(listPath, item.id);
 		}
 	};
 
 	//Calculate time remaining if purchase was less than 24 hours ago
-	const updateTimer = () => {
-		if (item.dateLastPurchased) {
-			const timeElapsed = Date.now() - item.dateLastPurchased.seconds * 1000;
-			if (timeElapsed < ONE_DAY_IN_MILLISECONDS) {
-				return ONE_DAY_IN_MILLISECONDS - timeElapsed;
-			} else {
-				return 0;
-			}
-		}
-	};
+	// const updateTimer = () => {
+	// 	if (item.dateLastPurchased) {
+	// 		const timeElapsed = Date.now() - item.dateLastPurchased.seconds * 1000;
+	// 		if (timeElapsed < ONE_DAY_IN_MILLISECONDS) {
+	// 			return ONE_DAY_IN_MILLISECONDS - timeElapsed;
+	// 		} else {
+	// 			return 0;
+	// 		}
+	// 	}
+	// };
 
 	//sets a timer to uncheck an item 24 hours after it's purchased
-	useEffect(() => {
-		if (purchasedOneDayAgo) {
-			let timeRemaining = updateTimer();
+	// useEffect(() => {
+	// 	if (purchasedOneDayAgo) {
+	// 		let timeRemaining = updateTimer();
 
-			const timer = setTimeout(() => {
-				setIsChecked(false);
-			}, timeRemaining);
-			return () => clearTimeout(timer);
-		}
-	}, [isChecked, purchasedOneDayAgo]);
+	// 		const timer = setTimeout(() => {
+	// 			setIsChecked(false);
+	// 		}, timeRemaining);
+	// 		return () => clearTimeout(timer);
+	// 	}
+	// }, [isChecked, purchasedOneDayAgo]);
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -52,30 +52,6 @@ export function ListItem({ listPath, item }) {
 		}
 	};
 
-	//Calculate time remaining if purchase was less than 24 hours ago
-	// const updateTimer = () => {
-	// 	if (item.dateLastPurchased) {
-	// 		const timeElapsed = Date.now() - item.dateLastPurchased.seconds * 1000;
-	// 		if (timeElapsed < ONE_DAY_IN_MILLISECONDS) {
-	// 			return ONE_DAY_IN_MILLISECONDS - timeElapsed;
-	// 		} else {
-	// 			return 0;
-	// 		}
-	// 	}
-	// };
-
-	//sets a timer to uncheck an item 24 hours after it's purchased
-	// useEffect(() => {
-	// 	if (purchasedOneDayAgo) {
-	// 		let timeRemaining = updateTimer();
-
-	// 		const timer = setTimeout(() => {
-	// 			setIsChecked(false);
-	// 		}, timeRemaining);
-	// 		return () => clearTimeout(timer);
-	// 	}
-	// }, [isChecked, purchasedOneDayAgo]);
-
 	return (
 		<li className="ListItem">
 			<label htmlFor={item.name}>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -9,8 +9,16 @@ export function ListItem({ listPath, item }) {
 	const lastPurchase =
 		item.dateLastPurchased[item.dateLastPurchased.length - 1];
 	const timeElapsed = Date.now() - lastPurchase.seconds * 1000;
+
 	//Boolean to pass into isChecked state
-	const purchasedWithinDay = timeElapsed <= ONE_DAY_IN_MILLISECONDS;
+	const purchasedWithinDay = () => {
+		//Exclude items that were just created and have never been purchased - new items are added to db with same dateCreated and first dateLastPurchased.
+		if (item.dateCreated.seconds == lastPurchase.seconds) {
+			return false;
+		} else {
+			return timeElapsed <= ONE_DAY_IN_MILLISECONDS;
+		}
+	};
 
 	//Box is checked on render if purchased within 24 hrs
 	const [isChecked, setIsChecked] = useState(purchasedWithinDay);


### PR DESCRIPTION
## Description

- Adjusts the way time since purchase is calculated and boolean logic for isChecked state to account for changes in the database
    - Checkbox element now displays as selected/unselected according to the last purchased date/time when loading the page
- Removes `updateTimer` function
- Fixes the `useEffect` containing `setTimeout` so there are no missing dependencies
    - Checkbox now unselects when 24 hours have passed from it being selected/purchased.

## Related Issue

Closes #36 

## Acceptance Criteria
- [x] The list item remains selected for 24 hours after being checked off, even when the page is refreshed or navigated away from.
- [x] The list item displays as unselected after 24 hours.

To explore:
- [x] Update the `useEffect` in `ListItem.jsx` so there is no longer a warning about missing dependencies when the app runs
  - Potential: Could nest the `updateTimer` function into the `useEffect`, or wrap it in a `useCallback` hook?

## Type of Changes

`bug fix`

## Updates

### Before

No changes to UI were made; no images can be provided for the changes.

## Testing Steps / QA Criteria

- Open test deployment link or pull branch `ap-list-item-behavior` and run `npm start`.
- Sign in to your account and select the dinner list.
- Click a checkbox to mark an item as purchased (e.g. cat treats). Note: The item should remain checked, but may move location in the list depending on the new calculated dateNextPurchased.
- Navigate to Firebase, then to the item you marked as purchased in the list.
- Change the last purchased date to the previous day, and adjust the hour/minute ahead so you have enough time to navigate back to the List page.
- The item should uncheck on its own once 24 hours have passed from your adjusted last purchased date, without a page refresh needed.
- Select another item on the List page.
- Refresh the List page and ensure that the item remains checked.