### PR TITLE
Install react-icons library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
+				"react-icons": "^5.0.1",
 				"react-router-dom": "^6.14.2"
 			},
 			"devDependencies": {
@@ -9605,6 +9606,14 @@
 			},
 			"peerDependencies": {
 				"react": "^18.2.0"
+			}
+		},
+		"node_modules/react-icons": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+			"integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+			"peerDependencies": {
+				"react": "*"
 			}
 		},
 		"node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-icons": "^5.0.1",
 		"react-router-dom": "^6.14.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description

- Install react-icons library

## Related Issue

Closes #49 

## Acceptance Criteria

- [x] react-icons is present in package.json as a dependency

## Type of Changes

`enhancement`

## Updates

### Before

No changes to UI were made; no images can be provided for the changes.

## Testing Steps / QA Criteria

- Checkout branch `ap-install-react-icons`
- Run `npm install` while in the project root directory
- Ensure that `react-icons` is in the `package.json` file as a dependency
- Optional:
    - Navigate to `Home.jsx` view
    - Import the following at the top of the file: `import { FaBeer } from "@react-icons/all-files/fa/FaBeer";`
    - Add `<FaBeer />` somewhere on the page, like in the welcome line.
    - Run `npm start`
    - Navigate to the Home view and ensure that a little beer icon shows up in the location you specified.