### PR TITLE
Basic conditional styling for logged out users

### DIFF
--- a/src/components/ListHeader.jsx
+++ b/src/components/ListHeader.jsx
@@ -1,6 +1,6 @@
 export function ListHeader({ text }) {
 	return (
-		<h2 className="mt-4 flex-1 bg-sage min-h-24 text-center content-center font-bold text-4xl mb-12 text-off-black">
+		<h2 className="mt-4 flex-1 bg-sage min-h-24 text-center content-center font-bold text-4xl mb-12 text-off-black px-4">
 			{text}
 		</h2>
 	);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,6 +3,8 @@ import { SingleList } from '../components/SingleList.jsx';
 import { useState } from 'react';
 import { createList } from '../api/firebase.js';
 import { useNavigate } from 'react-router-dom';
+import { auth } from '../api/config.js';
+import { IoBulbOutline } from 'react-icons/io5';
 
 export function Home({ data, userId, userEmail, setListPath }) {
 	const [newListName, setNewListName] = useState('');
@@ -49,38 +51,62 @@ export function Home({ data, userId, userEmail, setListPath }) {
 	};
 
 	return (
-		<div className="Home mt-8 font-Rubik mx-8 md:mx-24">
-			<form
-				onSubmit={handleSubmit}
-				className="flex rounded-lg items-center gap-x-6"
-			>
-				<label htmlFor="listName" className="text-off-black">
-					New list:
-				</label>
-				<input
-					type="text"
-					id="listName"
-					name="listName"
-					value={newListName}
-					onChange={handleChange}
-					className="border-2 border-sage rounded-lg min-h-14 bg-white grow text-xl xs:text-2xl text-off-black"
-				/>
-				<button className="bg-pale-green rounded-lg px-3 py-1 border-2 border-sage text-off-black">
-					Create
-				</button>
-			</form>
-			<ul className="flex flex-col my-8 items-center text-2xl">
-				{data.map((item, index) => {
-					return (
-						<SingleList
-							key={index}
-							name={item.name}
-							path={item.path}
-							setListPath={setListPath}
+		<div className="Home mt-8 font-Rubik mx-8 md:mx-24 h-min-content">
+			{!auth.currentUser ? (
+				<>
+					<section className="border border-dark-green py-8 px-12 text-off-black text-center tiny:mt-6 xs:mt-24 sm:mt-32 items-center justify-center bg-sage/75 rounded-2xl">
+						<h1 className="text-4xl xs:text-5xl font-semibold">
+							Welcome to Basket Buddy!
+						</h1>
+						<h2 className="italic">We're nacho average shopping list. </h2>
+					</section>
+					<section className="border border-dark-green py-8 px-12 text-off-black tiny:mt-14 items-center justify-center bg-sage/50 rounded-2xl">
+						<p className="font-semibold">
+							<IoBulbOutline className="inline h-8 text-4xl -mt-2" /> Get
+							Started :
+						</p>
+						<p>
+							Create your account by clicking the{' '}
+							<span className="font-medium">sign in</span> button above. You'll
+							be making and sharing lists in no time!
+						</p>
+					</section>
+				</>
+			) : (
+				<>
+					<form
+						onSubmit={handleSubmit}
+						className="flex rounded-lg items-center gap-x-6"
+					>
+						<label htmlFor="listName" className="text-off-black">
+							New list:
+						</label>
+						<input
+							type="text"
+							id="listName"
+							name="listName"
+							value={newListName}
+							onChange={handleChange}
+							className="border-2 border-sage rounded-lg min-h-14 bg-white grow text-xl xs:text-2xl text-off-black"
 						/>
-					);
-				})}
-			</ul>
+						<button className="bg-pale-green rounded-lg px-3 py-1 border-2 border-sage text-off-black">
+							Create
+						</button>
+					</form>
+					<ul className="flex flex-col my-8 items-center text-2xl">
+						{data.map((item, index) => {
+							return (
+								<SingleList
+									key={index}
+									name={item.name}
+									path={item.path}
+									setListPath={setListPath}
+								/>
+							);
+						})}
+					</ul>
+				</>
+			)}
 		</div>
 	);
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
 import { AddItem, ListItem } from '../components';
 import { ListHeader } from '../components/ListHeader.jsx';
+import { auth } from '../api/config.js';
 
 export function List({ data, listPath }) {
 	const [searchTerm, setSearchTerm] = useState('');
@@ -32,64 +33,74 @@ export function List({ data, listPath }) {
 
 	return (
 		<>
-			{listPath ? <ListHeader text={listName} /> : null}
-			{!listPath ? (
+			{!auth.currentUser ? (
+				<div className="border border-dark-green py-8 px-12 mx-8 md:mx-24 text-off-black text-center tiny:mt-18 xs:mt-32 sm:mt-40 items-center justify-center bg-sage/75 rounded-2xl font-medium">
+					Sign in to see your lists.
+				</div>
+			) : (
 				<>
-					<ListHeader text="You haven't selected a list yet. Click below to select a list." />
-					<div className="flex justify-center">
-						<button
-							onClick={() => handleClick('/')}
-							className="border border-dark-green rounded-xl px-4 py-2 hover:bg-pale-green text-off-black"
-						>
-							Select a list
-						</button>
-					</div>
-				</>
-			) : null}
-
-			<section className="mx-8 md:mx-24 flex flex-col">
-				{listPath ? <AddItem data={data} listPath={listPath} /> : null}
-				{data.length > 0 ? (
-					<section className="mt-8 mb-4">
-						<form className="flex flex-wrap items-center gap-x-6">
-							<label htmlFor="itemFilter" className="text-off-black">
-								Filter:
-							</label>
-							<input
-								type="text"
-								id="itemFilter"
-								name="itemFilter"
-								value={searchTerm}
-								onChange={handleChange}
-								className="bg-white border-solid border-2 rounded-xl border-sage pl-2 min-h-14 grow max-w-full mt-2 text-xl xs:text-2xl text-off-black"
-							/>
-							{searchTerm ? (
+					{listPath ? <ListHeader text={listName} /> : null}
+					{!listPath ? (
+						<>
+							<ListHeader text="You haven't selected a list yet. Click below to select a list." />
+							<div className="flex justify-center">
 								<button
-									onClick={reset}
-									className="bg-red-400 rounded-xl px-3 py-1 grow min-h-14 xs:max-w-28 mt-2 text-off-black"
+									onClick={() => handleClick('/')}
+									className="border border-dark-green rounded-xl px-4 py-2 hover:bg-pale-green text-off-black"
 								>
-									Reset
+									Select a list
 								</button>
-							) : null}
-						</form>
-					</section>
-				) : null}
-				{listPath && data.length === 0 ? (
-					<div className="bg-pale-green border border-dark-green rounded-xl py-8 mt-8">
-						<h3 className="text-center font-semibold text-off-black">
-							This list is currently empty!
-						</h3>
-					</div>
-				) : null}
+							</div>
+						</>
+					) : null}
 
-				<section>
-					<ul>
-						{filteredData.map((item) => {
-							return <ListItem key={item.id} item={item} listPath={listPath} />;
-						})}
-					</ul>
-				</section>
-			</section>
+					<section className="mx-8 md:mx-24 flex flex-col">
+						{listPath ? <AddItem data={data} listPath={listPath} /> : null}
+						{data.length > 0 ? (
+							<section className="mt-8 mb-4">
+								<form className="flex flex-wrap items-center gap-x-6">
+									<label htmlFor="itemFilter" className="text-off-black">
+										Filter:
+									</label>
+									<input
+										type="text"
+										id="itemFilter"
+										name="itemFilter"
+										value={searchTerm}
+										onChange={handleChange}
+										className="bg-white border-solid border-2 rounded-xl border-sage pl-2 min-h-14 grow max-w-full mt-2 text-xl xs:text-2xl text-off-black"
+									/>
+									{searchTerm ? (
+										<button
+											onClick={reset}
+											className="bg-red-400 rounded-xl px-3 py-1 grow min-h-14 xs:max-w-28 mt-2 text-off-black"
+										>
+											Reset
+										</button>
+									) : null}
+								</form>
+							</section>
+						) : null}
+						{listPath && data.length === 0 ? (
+							<div className="bg-pale-green border border-dark-green rounded-xl py-8 mt-8">
+								<h3 className="text-center font-semibold text-off-black">
+									This list is currently empty!
+								</h3>
+							</div>
+						) : null}
+
+						<section>
+							<ul>
+								{filteredData.map((item) => {
+									return (
+										<ListItem key={item.id} item={item} listPath={listPath} />
+									);
+								})}
+							</ul>
+						</section>
+					</section>
+				</>
+			)}
 		</>
 	);
 }

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { deleteList, shareList } from '../api/firebase.js';
 import { ListHeader } from '../components/ListHeader.jsx';
+import { auth } from '../api/config.js';
 
 export function ManageList({ setListPath, listPath, userEmail, userId }) {
 	const navigate = useNavigate();
@@ -59,59 +60,70 @@ export function ManageList({ setListPath, listPath, userEmail, userId }) {
 
 	return (
 		<>
-			{listPath ? (
+			{!auth.currentUser ? (
+				<div className="border border-dark-green py-8 px-12 mx-8 md:mx-24 text-off-black text-center tiny:mt-18 xs:mt-32 sm:mt-40 items-center justify-center bg-sage/75 rounded-2xl font-medium">
+					Sign in to manage lists.
+				</div>
+			) : (
 				<>
-					<ListHeader text={listName} />
-					<section className="mx-8 md:mx-24">
-						<form onSubmit={handleShareSubmit} className="w-full">
-							<div>
-								<label htmlFor="shareEmail" className="text-4xl text-off-black">
-									Share List
-								</label>
-							</div>
-							<div className="flex flex-wrap xs:flex-nowrap gap-x-6">
-								<input
-									id="shareEmail"
-									name="shareEmail"
-									type="email"
-									value={shareEmail}
-									placeholder="Enter Recipient Email"
-									onChange={handleShareChange}
-									className="bg-white border-solid border-2 rounded-xl border-sage pl-2 min-h-14 md:w-8/12 grow mt-4 text-xl xs:text-2xl text-off-black"
-								></input>
+					{listPath ? (
+						<>
+							<ListHeader text={listName} />
+							<section className="mx-8 md:mx-24">
+								<form onSubmit={handleShareSubmit} className="w-full">
+									<div>
+										<label
+											htmlFor="shareEmail"
+											className="text-4xl text-off-black"
+										>
+											Share List
+										</label>
+									</div>
+									<div className="flex flex-wrap xs:flex-nowrap gap-x-6">
+										<input
+											id="shareEmail"
+											name="shareEmail"
+											type="email"
+											value={shareEmail}
+											placeholder="Enter Recipient Email"
+											onChange={handleShareChange}
+											className="bg-white border-solid border-2 rounded-xl border-sage pl-2 min-h-14 md:w-8/12 grow mt-4 text-xl xs:text-2xl text-off-black"
+										></input>
+										<button
+											type="submit"
+											className="bg-sage p-2 px-4 rounded-xl text-3xl min-h-14 mt-4 grow xs:grow-0 text-off-black"
+										>
+											Send invite!
+										</button>
+									</div>
+								</form>
+							</section>
+							<section className="mx-8 md:mx-24 mt-24">
+								<h3 className="text-4xl text-off-black">List Options</h3>
 								<button
-									type="submit"
-									className="bg-sage p-2 px-4 rounded-xl text-3xl min-h-14 mt-4 grow xs:grow-0 text-off-black"
+									onClick={handleDelete}
+									className="mt-4 bg-red-400/80 min-h-14 px-24 rounded-xl text-3xl w-full text-off-black"
 								>
-									Send invite!
+									Delete List
+								</button>
+							</section>
+						</>
+					) : null}
+					{!listPath ? (
+						<>
+							<ListHeader text="You haven't selected a list yet. Click below to select a list." />
+							<div className="flex justify-center">
+								<button
+									onClick={() => handleClick('/')}
+									className="border border-dark-green rounded-xl px-4 py-2 hover:bg-pale-green text-off-black"
+								>
+									Select a list
 								</button>
 							</div>
-						</form>
-					</section>
-					<section className="mx-8 md:mx-24 mt-24">
-						<h3 className="text-4xl text-off-black">List Options</h3>
-						<button
-							onClick={handleDelete}
-							className="mt-4 bg-red-400/80 min-h-14 px-24 rounded-xl text-3xl w-full text-off-black"
-						>
-							Delete List
-						</button>
-					</section>
+						</>
+					) : null}
 				</>
-			) : null}
-			{!listPath ? (
-				<>
-					<ListHeader text="You haven't selected a list yet. Click below to select a list." />
-					<div className="flex justify-center">
-						<button
-							onClick={() => handleClick('/')}
-							className="border border-dark-green rounded-xl px-4 py-2 hover:bg-pale-green text-off-black"
-						>
-							Select a list
-						</button>
-					</div>
-				</>
-			) : null}
+			)}
 		</>
 	);
 }


### PR DESCRIPTION
## Description

- Added conditional styling to Home (hid new list form), List, and Manage List pages when a user is logged out. Improves user experience.
- Adjusted ListHeader padding for small screens

## Related Issue

N/A

## Acceptance Criteria

N/A

## Type of Changes

`enhancement`

## Updates

### Before
Home view
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/cd1a2e4e-403c-432b-9780-2912678b1510)

List & Manage List view
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/733ba707-58ca-495b-9f8b-e2d71fb7ce76)

ListHeader padding
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/39fca92f-9d78-4629-ad68-6d8e545c79e6)

### After

Home view
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/1fb18a48-7211-40da-997f-a8282bec9a86)

List view
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/1b971e02-ff90-4c71-9f35-020fcf7e03cc)

Manage List view
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/6d34828c-28ed-4ce9-8fe9-a939c6f19236)

ListHeader padding
![image](https://github.com/the-collab-lab/tcl-68-smart-shopping-list/assets/98671035/22fb6079-d0ca-44c7-9bef-7a7a74923479)

## Testing Steps / QA Criteria

- Open deployment link or pull branch `ap-logged-out`.
- Confirm that you are signed out.
- Clear local storage to ensure there is no list path.
- Navigate to the Home, List, and ManageList pages and verify that they look like the screenshots.
- Navigate to List or ManageList page and sign in.
- Verify that the header looks like the screenshot.
- To double check that the conditional logic still works:
  - Navigate to Home page and select a list.
  - Verify that the List page looks as it did before with all components rendered.
